### PR TITLE
refactor: added component to easily fade in and out elements

### DIFF
--- a/apps/extension/src/components/visible-fade-animation/index.tsx
+++ b/apps/extension/src/components/visible-fade-animation/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Box } from 'ui/src/components/atoms'
+
+interface IProps {
+	isVisible: boolean
+}
+
+export const VisibleFadeAnimation: React.FC<IProps> = ({ isVisible, children }) => (
+	<Box
+		css={{
+			pe: !isVisible ? 'none' : 'auto',
+			opacity: !isVisible ? '0' : '1',
+			transition: '$default',
+		}}
+	>
+		{children}
+	</Box>
+)

--- a/apps/extension/src/containers/wallet-panel/accounts/token-list/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/accounts/token-list/index.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { useSharedStore, useStore } from '@src/store'
 import { useAllAccountsTokenBalances, useTokenBalances } from '@src/services/react-query/queries/radix'
 import { TokenLoadingRows } from '@src/components/token-loading-row'
+import { VisibleFadeAnimation } from '@src/components/visible-fade-animation'
 import { Virtuoso } from 'react-virtuoso'
 import { ScrollArea } from '@src/components/scroll-area'
 import { SLIDE_PANEL_HEIGHT, SLIDE_PANEL_EXPAND_HEIGHT, SLIDE_PANEL_HEADER_HEIGHT } from '@src/config'
@@ -111,17 +112,16 @@ export const TokenList: React.FC = () => {
 		addresses: Object.values(state.publicAddresses).map(({ address }) => address),
 		activeSlideIndex: state.activeSlideIndex,
 	}))
-	// @TODO: animate this, rather than conditionally show
 	const isSlideUpPanelVisible = activeSlideIndex < addresses.length
 
 	return (
 		<>
 			<AccountSwitcher />
-			{isSlideUpPanelVisible ? (
+			<VisibleFadeAnimation isVisible={isSlideUpPanelVisible}>
 				<SlideUpPanel name="Tokens">
 					<Balances />
 				</SlideUpPanel>
-			) : null}
+			</VisibleFadeAnimation>
 		</>
 	)
 }


### PR DESCRIPTION
## Description

This component is used for fading out the token list on the `add account` slide.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/94514262/172924441-07b85250-04f0-440a-9ad4-a2642e96b62b.png">
