### PR TITLE
refactor: remove `import accounts` step from the create wallet step

### DIFF
--- a/apps/extension/src/containers/onboarding/index.tsx
+++ b/apps/extension/src/containers/onboarding/index.tsx
@@ -51,7 +51,11 @@ export const OnboardingWorkFlow: React.FC = () => {
 				}
 				break
 			case onBoardingSteps.CREATE_PASSWORD:
-				setOnboardingStep(onBoardingSteps.IMPORT_ACCOUNTS)
+				if (isRestoreWorkflow) {
+					setOnboardingStep(onBoardingSteps.IMPORT_ACCOUNTS)
+				} else {
+					setOnboardingStep(onBoardingSteps.GENERATE_PHRASE)
+				}
 				break
 			case onBoardingSteps.CREATE_WALLET:
 				setOnboardingStep(onBoardingSteps.CREATE_PASSWORD)

--- a/apps/extension/src/containers/onboarding/steps/2a-generate-phrase/index.tsx
+++ b/apps/extension/src/containers/onboarding/steps/2a-generate-phrase/index.tsx
@@ -45,7 +45,7 @@ export const GeneratePhrase = (): JSX.Element => {
 	}, [])
 
 	const handleContinue = () => {
-		setOnboardingStep(onBoardingSteps.IMPORT_ACCOUNTS)
+		setOnboardingStep(onBoardingSteps.CREATE_PASSWORD)
 	}
 
 	const handleCopyMnemomic = () => {


### PR DESCRIPTION
## Description

Removing the `import accounts` step from `wallet creation` will make the onboarding process more simple.