### PR TITLE
enhancement(Dialog): improve token color for transparent dialog color

### DIFF
--- a/packages/ui/src/components/alert-dialog/index.tsx
+++ b/packages/ui/src/components/alert-dialog/index.tsx
@@ -28,7 +28,7 @@ const animateOut = keyframes({
 
 const StyledOverlayExtension = styled(AlertDialogPrimitive.Overlay, {
 	backgroundColor: '$bgTransparentDialog',
-	backdropFilter: 'blur(6px)',
+	backdropFilter: 'blur(5px)',
 	position: 'absolute',
 	width: EXT_WIDTH,
 	height: EXT_HEIGHT,

--- a/packages/ui/src/theme/dark-colors.ts
+++ b/packages/ui/src/theme/dark-colors.ts
@@ -14,7 +14,7 @@ export const darkColors = {
 	bgToggleActive: '#aca7d3',
 	bgSlider: '#000000',
 	bgSliderRange: '#aca7d3',
-	bgTransparentDialog: 'rgba(0,0,0, 0.7)',
+	bgTransparentDialog: 'rgba(0,0,0, 0.4)',
 	bgSliderTrack: '$buttonBgPrimary',
 	bgInput: '#111111',
 	bgLink: 'rgba(192,125,219,0.1)',


### PR DESCRIPTION
## Description

Improved token color for the dialog backdrop
<img width="394" alt="image" src="https://user-images.githubusercontent.com/94514262/172938737-057c7bf7-e237-46b5-abd6-e330bab68d39.png">

