### PR TITLE
fix: show xrd total in token row

### DIFF
--- a/apps/extension/src/containers/wallet-panel/accounts/token-list/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/accounts/token-list/index.tsx
@@ -117,6 +117,7 @@ const AllBalances: React.FC = () => {
 						rri={rri}
 						amount={amount}
 						staked={symbol === 'xrd' && staked ? staked : null}
+						symbol={symbol}
 						disableClick
 					/>
 				)}
@@ -177,6 +178,7 @@ const AccountBalances: React.FC = () => {
 						rri={rri}
 						amount={amount || 0}
 						staked={symbol === 'xrd' && staked ? staked : null}
+						symbol={symbol}
 						loading={isLoading}
 					/>
 				)}

--- a/apps/extension/src/containers/wallet-panel/accounts/token-row/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/accounts/token-row/index.tsx
@@ -4,8 +4,8 @@ import { formatBigNumber } from '@src/utils/formatters'
 import { useTokenInfo } from '@src/hooks/react-query/queries/radix'
 import { useLocation } from 'wouter'
 import { Box, Flex, Text } from 'ui/src/components/atoms'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from 'ui/src/components/hover-card'
 import Button from 'ui/src/components/button'
-import { ToolTip } from 'ui/src/components/tool-tip'
 import { CircleAvatar } from '@src/components/circle-avatar'
 import { InfoCircledIcon } from '@radix-ui/react-icons'
 import { TokenPrice } from './token-price'
@@ -13,6 +13,7 @@ import { TokenPrice } from './token-price'
 interface IProps {
 	i: number
 	rri: string
+	symbol: string
 	amount: string | BigNumber
 	staked?: string | BigNumber
 	loading?: boolean
@@ -25,7 +26,7 @@ const defaultProps = {
 	disableClick: false,
 }
 
-export const TokenRow: React.FC<IProps> = ({ i, rri, amount, staked, loading, disableClick }) => {
+export const TokenRow: React.FC<IProps> = ({ i, rri, symbol, amount, staked, loading, disableClick }) => {
 	const { isLoading: isLoadingTokenInfo, data: token } = useTokenInfo(rri)
 	const [, setLocation] = useLocation()
 	const isLoadingComplete = !loading && !isLoadingTokenInfo
@@ -80,20 +81,37 @@ export const TokenRow: React.FC<IProps> = ({ i, rri, amount, staked, loading, di
 								</Text>
 								<Flex css={{ mt: '2px' }}>
 									<Text color="help" size="3">
-										{formatBigNumber(tokenAmount)}
+										{staked && symbol === 'xrd'
+											? formatBigNumber(tokenAmount.plus(stakedAmount))
+											: formatBigNumber(tokenAmount)}
 									</Text>
 									{staked && !stakedAmount.isZero() && (
 										<Flex css={{ maxWidth: '115px', position: 'relative' }}>
-											<Text truncate color="help" size="3" css={{ pl: '$1' }}>
-												+ staked
-											</Text>
-											<ToolTip message={formatBigNumber(stakedAmount)} sideOffset={3} side="top">
-												<Box css={{ mt: '-5px' }}>
-													<Button size="1" color="ghost" iconOnly clickable={false} css={{ color: '$txtHelp' }}>
-														<InfoCircledIcon />
-													</Button>
-												</Box>
-											</ToolTip>
+											<HoverCard>
+												<HoverCardTrigger asChild>
+													<Box css={{ mt: '-5px' }}>
+														<Button size="1" color="ghost" iconOnly clickable={false} css={{ color: '$txtHelp' }}>
+															<InfoCircledIcon />
+														</Button>
+													</Box>
+												</HoverCardTrigger>
+												<HoverCardContent side="top" sideOffset={0} css={{ maxWidth: '170px' }}>
+													<Box>
+														<Text as="p">
+															<Text as="span" bold>
+																XRD Available:
+															</Text>
+															<Text as="span">{formatBigNumber(tokenAmount)}</Text>
+														</Text>
+														<Text as="p" css={{ pt: '$2' }}>
+															<Text as="span" bold>
+																XRD Staked or Unstaking:
+															</Text>
+															<Text as="span">{formatBigNumber(stakedAmount)}</Text>
+														</Text>
+													</Box>
+												</HoverCardContent>
+											</HoverCard>
 										</Flex>
 									)}
 								</Flex>

--- a/packages/ui/src/components/hover-card/index.tsx
+++ b/packages/ui/src/components/hover-card/index.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 import { styled, keyframes } from '@stitches/react'
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card'
 
+const animateOut = keyframes({
+	from: { transform: 'translateY(0)', opacity: 1 },
+	to: { transform: 'translateY(4px)', opacity: 0 },
+})
+
 const slideUpAndFade = keyframes({
 	'0%': { opacity: 0, transform: 'translateY(2px)' },
 	'100%': { opacity: 1, transform: 'translateY(0)' },
@@ -29,6 +34,10 @@ const StyledContent = styled(HoverCardPrimitive.Content, {
 	backgroundColor: '$bgPanel',
 	boxShadow: '$tooltip',
 	'@media (prefers-reduced-motion: no-preference)': {
+		'&[data-state="closed"]': {
+			animation: `${animateOut} 300ms ease`,
+			animationFillMode: 'forwards',
+		},
 		animationDuration: '400ms',
 		animationTimingFunction: 'cubic-beer(0.16, 1, 0.3, 1)',
 		animationFillMode: 'forwards',


### PR DESCRIPTION
## Description

Show xrd total in token row with hover card for staked and available balances

![image](https://user-images.githubusercontent.com/94514262/182261171-feba22e1-1ed0-4f6f-bdd3-1744422277e0.png)

