### PR TITLE
Swap Pool Selector - do not cut Doge avatars.

### DIFF
--- a/apps/extension/src/components/circle-avatar/index.tsx
+++ b/apps/extension/src/components/circle-avatar/index.tsx
@@ -11,6 +11,7 @@ interface IProps {
 	borderWidth?: number
 	shadow?: boolean
 	background?: string
+	cutImage?: boolean
 	avatarFallBackCss?: CSS
 }
 const defaultProps = {
@@ -21,6 +22,7 @@ const defaultProps = {
 	borderWidth: 2,
 	shadow: true,
 	background: '#b0c3dd',
+	cutImage: true,
 	avatarFallBackCss: {},
 }
 
@@ -32,6 +34,7 @@ export const CircleAvatar: React.FC<IProps> = ({
 	borderWidth,
 	shadow,
 	background,
+	cutImage,
 	avatarFallBackCss,
 }) =>
 	image ? (
@@ -52,7 +55,7 @@ export const CircleAvatar: React.FC<IProps> = ({
 					height: `${height}px`,
 				}}
 			>
-				<AvatarImage src={image} alt={fallbackText} />
+				<AvatarImage src={image} alt={fallbackText} css={{ ...(!cutImage ? {borderRadius: 'unset'} : {}) }} />
 				<AvatarFallback
 					delayMs={200}
 					css={{ borderRadius: '50%', backgroundColor: '$bgPanel', overflow: 'hidden', ...(avatarFallBackCss as any) }}

--- a/apps/extension/src/containers/wallet-panel/swap/pool-selector/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/swap/pool-selector/index.tsx
@@ -16,7 +16,7 @@ import {
 import { CircleAvatar } from '@src/components/circle-avatar'
 import { Box, Text, Flex } from 'ui/src/components/atoms'
 import Button from 'ui/src/components/button'
-import { Pool } from '@src/types'
+import { Pool, PoolType } from '@src/types'
 import useMeasure from 'react-use-measure'
 
 interface IProps {
@@ -63,7 +63,8 @@ export const PoolSelector: React.FC<IProps> = ({ pool, pools, onPoolChange }) =>
 					}}
 				>
 					<Box css={{ p: '8px' }}>
-						<CircleAvatar image={selected?.image} fallbackText={selected?.type.toLocaleUpperCase()} />
+						<CircleAvatar image={selected?.image} fallbackText={selected?.type.toLocaleUpperCase()}
+													cutImage={selected?.type !== PoolType.DOGECUBEX} />
 					</Box>
 					<Box css={{ flex: '1' }}>
 						<Flex css={{ mt: '2px' }}>


### PR DESCRIPTION
# Swap Pool Selector - do not cut Doge avatars.


## Description

Better looks for DogeCube avatars in poll selector.

## Screenshot
Before:
![image](https://user-images.githubusercontent.com/97917768/182656661-07792baa-c72b-4a38-bd5f-e323bbd20692.png)
After:
![image](https://user-images.githubusercontent.com/97917768/182656801-e8b71900-c5d2-4e13-81f3-e266e29ad0f7.png)


## Steps to Verify

Go to Swaps tab (currently disabled) and pick token OCI, pool - DogeCubeX.