### PR TITLE
fix: cleanup keystores on popup disconnect

### DIFF
--- a/apps/extension/src/components/locked-panel/index.tsx
+++ b/apps/extension/src/components/locked-panel/index.tsx
@@ -170,32 +170,34 @@ export const LockedPanel: React.FC = () => {
 
 				<form onSubmit={handleSubmitForm}>
 					<Box css={{ p: '$6' }}>
-						{keystore.type === KeystoreType.LOCAL && (
-							<Box>
-								<Input
-									type="password"
-									size="2"
-									ref={inputRef}
-									placeholder="Enter password"
-									focusOnMount
-									value={state.password}
-									error={state.passwordError}
-									onChange={handlePasswordChange}
-								/>
-								<InputFeedBack showFeedback={state.passwordError} animateHeight={31}>
-									<StyledLink underlineOnHover href="#/onboarding" css={{ display: 'block', mt: '12px' }}>
-										<Text uppercase medium>
-											Forgot password?
-										</Text>
-									</StyledLink>
-								</InputFeedBack>
-							</Box>
+						{keystore?.type === KeystoreType.LOCAL && (
+							<>
+								<Box>
+									<Input
+										type="password"
+										size="2"
+										ref={inputRef}
+										placeholder="Enter password"
+										focusOnMount
+										value={state.password}
+										error={state.passwordError}
+										onChange={handlePasswordChange}
+									/>
+									<InputFeedBack showFeedback={state.passwordError} animateHeight={31}>
+										<StyledLink underlineOnHover href="#/onboarding" css={{ display: 'block', mt: '12px' }}>
+											<Text uppercase medium>
+												Forgot password?
+											</Text>
+										</StyledLink>
+									</InputFeedBack>
+								</Box>
+								<Flex css={{ mt: '$3' }}>
+									<Button type="submit" loading={state.isLoading} color="primary" size="6" css={{ flex: '1' }}>
+										Unlock
+									</Button>
+								</Flex>
+							</>
 						)}
-						<Flex css={{ mt: '$3' }}>
-							<Button type="submit" loading={state.isLoading} color="primary" size="6" css={{ flex: '1' }}>
-								Unlock
-							</Button>
-						</Flex>
 					</Box>
 				</form>
 			</Flex>

--- a/apps/extension/src/components/locked-panel/index.tsx
+++ b/apps/extension/src/components/locked-panel/index.tsx
@@ -171,33 +171,31 @@ export const LockedPanel: React.FC = () => {
 				<form onSubmit={handleSubmitForm}>
 					<Box css={{ p: '$6' }}>
 						{keystore?.type === KeystoreType.LOCAL && (
-							<>
-								<Box>
-									<Input
-										type="password"
-										size="2"
-										ref={inputRef}
-										placeholder="Enter password"
-										focusOnMount
-										value={state.password}
-										error={state.passwordError}
-										onChange={handlePasswordChange}
-									/>
-									<InputFeedBack showFeedback={state.passwordError} animateHeight={31}>
-										<StyledLink underlineOnHover href="#/onboarding" css={{ display: 'block', mt: '12px' }}>
-											<Text uppercase medium>
-												Forgot password?
-											</Text>
-										</StyledLink>
-									</InputFeedBack>
-								</Box>
-								<Flex css={{ mt: '$3' }}>
-									<Button type="submit" loading={state.isLoading} color="primary" size="6" css={{ flex: '1' }}>
-										Unlock
-									</Button>
-								</Flex>
-							</>
+							<Box>
+								<Input
+									type="password"
+									size="2"
+									ref={inputRef}
+									placeholder="Enter password"
+									focusOnMount
+									value={state.password}
+									error={state.passwordError}
+									onChange={handlePasswordChange}
+								/>
+								<InputFeedBack showFeedback={state.passwordError} animateHeight={31}>
+									<StyledLink underlineOnHover href="#/onboarding" css={{ display: 'block', mt: '12px' }}>
+										<Text uppercase medium>
+											Forgot password?
+										</Text>
+									</StyledLink>
+								</InputFeedBack>
+							</Box>
 						)}
+						<Flex css={{ mt: '$3' }}>
+							<Button type="submit" loading={state.isLoading} color="primary" size="6" css={{ flex: '1' }}>
+								Unlock
+							</Button>
+						</Flex>
 					</Box>
 				</form>
 			</Flex>

--- a/apps/extension/src/components/z3us-menu/index.tsx
+++ b/apps/extension/src/components/z3us-menu/index.tsx
@@ -106,7 +106,7 @@ export const Z3usMenu: React.FC = () => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, type, false)
+		addKeystore(id, id, type)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/components/z3us-menu/index.tsx
+++ b/apps/extension/src/components/z3us-menu/index.tsx
@@ -106,7 +106,7 @@ export const Z3usMenu: React.FC = () => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, type)
+		addKeystore(id, id, type, false)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/containers/hardware-wallet/steps/1-import-accounts/index.tsx
+++ b/apps/extension/src/containers/hardware-wallet/steps/1-import-accounts/index.tsx
@@ -67,7 +67,7 @@ export const ImportAccounts = (): JSX.Element => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, KeystoreType.HARDWARE, false)
+		addKeystore(id, id, KeystoreType.HARDWARE)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/containers/hardware-wallet/steps/1-import-accounts/index.tsx
+++ b/apps/extension/src/containers/hardware-wallet/steps/1-import-accounts/index.tsx
@@ -67,7 +67,7 @@ export const ImportAccounts = (): JSX.Element => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, KeystoreType.HARDWARE)
+		addKeystore(id, id, KeystoreType.HARDWARE, false)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/containers/hardware-wallet/steps/1-import-accounts/index.tsx
+++ b/apps/extension/src/containers/hardware-wallet/steps/1-import-accounts/index.tsx
@@ -67,7 +67,7 @@ export const ImportAccounts = (): JSX.Element => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, KeystoreType.HARDWARE, false)
+		addKeystore(id, id, KeystoreType.HARDWARE, true)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/containers/onboarding/index.tsx
+++ b/apps/extension/src/containers/onboarding/index.tsx
@@ -19,15 +19,15 @@ import { useColorMode } from '@src/hooks/use-color-mode'
 export const OnboardingWorkFlow: React.FC = () => {
 	const [, setLocation] = useLocation()
 	const isDarkMode = useColorMode()
-	const { keystores, onBoardingStep, setOnboardingStep, setIsRestoreWorkflow, isRestoreWorkflow } = useSharedStore(
-		state => ({
+	const { keystores, cleanKeystores, onBoardingStep, setOnboardingStep, setIsRestoreWorkflow, isRestoreWorkflow } =
+		useSharedStore(state => ({
 			keystores: state.keystores,
+			cleanKeystores: state.cleanKeystoresAction,
 			onBoardingStep: state.onBoardingStep,
 			setOnboardingStep: state.setOnboardingStepAction,
 			setIsRestoreWorkflow: state.setIsRestoreWorkflowAction,
 			isRestoreWorkflow: state.isRestoreWorkflow,
-		}),
-	)
+		}))
 
 	const showBackBtn = keystores.length > 0 || onBoardingStep !== onBoardingSteps.START
 
@@ -35,6 +35,7 @@ export const OnboardingWorkFlow: React.FC = () => {
 		switch (onBoardingStep) {
 			case onBoardingSteps.START:
 				setLocation('#/wallet/account')
+				cleanKeystores()
 				break
 			case onBoardingSteps.GENERATE_PHRASE:
 				setIsRestoreWorkflow(false)

--- a/apps/extension/src/containers/onboarding/steps/1-start/index.tsx
+++ b/apps/extension/src/containers/onboarding/steps/1-start/index.tsx
@@ -59,7 +59,7 @@ export const Start = (): JSX.Element => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, type, false)
+		addKeystore(id, id, type)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/containers/onboarding/steps/1-start/index.tsx
+++ b/apps/extension/src/containers/onboarding/steps/1-start/index.tsx
@@ -59,7 +59,7 @@ export const Start = (): JSX.Element => {
 		}
 
 		const id = generateId()
-		addKeystore(id, id, type)
+		addKeystore(id, id, type, false)
 		await lock() // clear background memory
 	}
 

--- a/apps/extension/src/containers/onboarding/steps/5-create-wallet/index.tsx
+++ b/apps/extension/src/containers/onboarding/steps/5-create-wallet/index.tsx
@@ -21,22 +21,25 @@ export const CreateWallet = (): JSX.Element => {
 	const queryClient = useQueryClient()
 
 	const {
+		keystoreId,
 		mnemonic,
 		password,
 		setPassword,
 		setMnemomic,
+		changeKeystoreStatusForPassword,
 		isRestoreWorkflow,
 		createWallet,
 		setIsRestoreWorkflow,
 		setOnboradingStep,
 		setSeed,
 	} = useSharedStore(state => ({
+		keystoreId: state.selectKeystoreId,
 		mnemonic: state.mnemonic,
 		password: state.password,
 		createWallet: state.createWalletAction,
 		setPassword: state.setPasswordAction,
 		setMnemomic: state.setMnemomicAction,
-
+		changeKeystoreStatusForPassword: state.changeKeystoreStatusForPasswordAction,
 		isRestoreWorkflow: state.isRestoreWorkflow,
 		setIsRestoreWorkflow: state.setIsRestoreWorkflowAction,
 		setOnboradingStep: state.setOnboardingStepAction,
@@ -68,10 +71,11 @@ export const CreateWallet = (): JSX.Element => {
 		try {
 			const seed = await createWallet(mnemonic.words, password)
 			setSeed(seed)
-			await selectAccount(0, null, seed)
 
+			await selectAccount(0, null, seed)
 			await queryClient.invalidateQueries({ active: true, inactive: true, stale: true })
 
+			changeKeystoreStatusForPassword(keystoreId, true)
 			setPassword(null)
 			setMnemomic(null)
 			setOnboradingStep(onBoardingSteps.START)

--- a/apps/extension/src/lib/background.ts
+++ b/apps/extension/src/lib/background.ts
@@ -78,6 +78,9 @@ browser.runtime.onConnect.addListener(port => {
 			console.error(`Disconnected due to an error: ${port.error.message}`)
 		}
 
+		const { cleanKeystoresAction } = sharedStore.getState()
+		cleanKeystoresAction()
+
 		Object.keys(portMessageIDs).forEach(async id => {
 			await deletePendingAction(id)
 

--- a/apps/extension/src/store/keystores.ts
+++ b/apps/extension/src/store/keystores.ts
@@ -7,9 +7,9 @@ export const factory = (set: SetState<SharedStore>): KeystoresStore => ({
 	keystores: [],
 	selectKeystoreId: '',
 
-	addKeystoreAction: (id: string, name: string, type: KeystoreType) => {
+	addKeystoreAction: (id: string, name: string, type: KeystoreType, hasPassword: boolean) => {
 		set(draft => {
-			draft.keystores = [...draft.keystores, { id, name, type, hasPassword: false }]
+			draft.keystores = [...draft.keystores, { id, name, type, hasPassword }]
 			draft.selectKeystoreId = id
 		})
 	},

--- a/apps/extension/src/store/keystores.ts
+++ b/apps/extension/src/store/keystores.ts
@@ -7,9 +7,9 @@ export const factory = (set: SetState<SharedStore>): KeystoresStore => ({
 	keystores: [],
 	selectKeystoreId: '',
 
-	addKeystoreAction: (id: string, name: string, type: KeystoreType, hasPassword: boolean) => {
+	addKeystoreAction: (id: string, name: string, type: KeystoreType) => {
 		set(draft => {
-			draft.keystores = [...draft.keystores, { id, name, type, hasPassword }]
+			draft.keystores = [...draft.keystores, { id, name, type, hasPassword: false }]
 			draft.selectKeystoreId = id
 		})
 	},

--- a/apps/extension/src/store/keystores.ts
+++ b/apps/extension/src/store/keystores.ts
@@ -7,16 +7,33 @@ export const factory = (set: SetState<SharedStore>): KeystoresStore => ({
 	keystores: [],
 	selectKeystoreId: '',
 
-	addKeystoreAction: (id: string, name: string, type: KeystoreType) => {
+	addKeystoreAction: (id: string, name: string, type: KeystoreType, hasPassword: boolean) => {
 		set(draft => {
-			draft.keystores = [...draft.keystores, { id, name, type }]
+			draft.keystores = [...draft.keystores, { id, name, type, hasPassword }]
 			draft.selectKeystoreId = id
+		})
+	},
+
+	// @NOTE: In the case that the user does not complete the `restore` process, the keystore is removed.
+	cleanKeystoresAction: async () => {
+		set(draft => {
+			const keystoresNotSetup = draft.keystores.filter(_keystore => !_keystore.hasPassword)
+			const isNotSetupKeystoreSelected = keystoresNotSetup.some(({ id }) => id === draft.selectKeystoreId)
+			const updatedKeyStores = draft.keystores.filter(_keystore => _keystore.hasPassword)
+			draft.keystores = updatedKeyStores
+			draft.selectKeystoreId = isNotSetupKeystoreSelected ? updatedKeyStores?.[0]?.id : draft.selectKeystoreId
 		})
 	},
 
 	changeKeystoreNameAction: (id: string, name: string) => {
 		set(draft => {
 			draft.keystores = draft.keystores.map(keystore => (keystore.id === id ? { ...keystore, name } : keystore))
+		})
+	},
+
+	changeKeystoreStatusForPasswordAction: (id: string, hasPassword: boolean) => {
+		set(draft => {
+			draft.keystores = draft.keystores.map(keystore => (keystore.id === id ? { ...keystore, hasPassword } : keystore))
 		})
 	},
 

--- a/apps/extension/src/store/onboarding.ts
+++ b/apps/extension/src/store/onboarding.ts
@@ -24,7 +24,6 @@ export const factory = (set: SetState<SharedStore>): OnBoardingStore => ({
 	isRestoreWorkflow: false,
 	mnemonic: null,
 	password: null,
-
 	connectHardwareWalletStep: connectHardwareWalletSteps.IMPORT_ACCOUNTS,
 
 	setMnemomicAction: (mnemonic: Mnemomic): void =>

--- a/apps/extension/src/store/types.ts
+++ b/apps/extension/src/store/types.ts
@@ -114,7 +114,7 @@ export type KeystoresStore = {
 	selectKeystoreAction: (id: string) => void
 
 	keystores: Keystore[]
-	addKeystoreAction: (id: string, name: string, type: KeystoreType) => void
+	addKeystoreAction: (id: string, name: string, type: KeystoreType, hasPassword: boolean) => void
 	cleanKeystoresAction: () => void
 	removeKeystoreAction: (id: string) => void
 	changeKeystoreNameAction: (id: string, name: string) => void

--- a/apps/extension/src/store/types.ts
+++ b/apps/extension/src/store/types.ts
@@ -114,7 +114,7 @@ export type KeystoresStore = {
 	selectKeystoreAction: (id: string) => void
 
 	keystores: Keystore[]
-	addKeystoreAction: (id: string, name: string, type: KeystoreType, hasPassword: boolean) => void
+	addKeystoreAction: (id: string, name: string, type: KeystoreType) => void
 	cleanKeystoresAction: () => void
 	removeKeystoreAction: (id: string) => void
 	changeKeystoreNameAction: (id: string, name: string) => void

--- a/apps/extension/src/store/types.ts
+++ b/apps/extension/src/store/types.ts
@@ -37,6 +37,7 @@ export type Keystore = {
 	id: string
 	name: string
 	type: KeystoreType
+	hasPassword: boolean
 }
 
 export type ToastsStore = {
@@ -113,9 +114,11 @@ export type KeystoresStore = {
 	selectKeystoreAction: (id: string) => void
 
 	keystores: Keystore[]
-	addKeystoreAction: (id: string, name: string, type: KeystoreType) => void
+	addKeystoreAction: (id: string, name: string, type: KeystoreType, hasPassword: boolean) => void
+	cleanKeystoresAction: () => void
 	removeKeystoreAction: (id: string) => void
 	changeKeystoreNameAction: (id: string, name: string) => void
+	changeKeystoreStatusForPasswordAction: (id: string, hasPassword: boolean) => void
 }
 
 export type LocalWalletStore = {


### PR DESCRIPTION
## Description

When a user enters the process to restore wallet from seed phrase,
the keystore is created even if they do not enter the password for the
account. The result was that the z3us menu could be filled up with
keystores that the user can not access.
This PR creates a clean up method for keystores that are not properly
setup, and removes them from the store, when the popup closes.

