### PR TITLE
Fix/zgod/swap updates

### DIFF
--- a/apps/extension/src/containers/wallet-panel/swap/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/swap/index.tsx
@@ -389,7 +389,7 @@ export const Swap: React.FC = () => {
 											textTransform: 'uppercase',
 										}}
 										onClick={handleUseMax}
-										loading={state.isLoading}
+										disabled={state.isLoading}
 									>
 										MAX
 									</Button>
@@ -428,7 +428,7 @@ export const Swap: React.FC = () => {
 									size="1"
 									color="tertiary"
 									onClick={handleSwitchTokens}
-									loading={state.isLoading}
+									disabled={state.isLoading}
 									css={{
 										svg: {
 											transition: '$default',

--- a/apps/extension/src/containers/wallet-panel/swap/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/swap/index.tsx
@@ -410,7 +410,6 @@ export const Swap: React.FC = () => {
 								value={state.amount}
 								placeholder="Enter amount"
 								onChange={handleSetAmount}
-								disabled={state.isLoading}
 							/>
 							<TokenSelector
 								triggerType="input"
@@ -487,7 +486,6 @@ export const Swap: React.FC = () => {
 								value={state.receive}
 								placeholder="Receive"
 								onChange={handleSetReceive}
-								disabled={state.isLoading}
 							/>
 							<TokenSelector
 								triggerType="input"

--- a/apps/extension/src/containers/wallet-panel/swap/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/swap/index.tsx
@@ -50,6 +50,9 @@ interface ImmerState {
 	isFeeUiVisible: boolean
 }
 
+// Test for positive numbers only allow max 9 decimals
+const REGEX_INPUT = /^\d*(\.\d{0,9})?$/i
+
 const refreshInterval = 5 * 1000 // 5 seconds
 const debounceInterval = 500 // 0.5 sec
 
@@ -292,39 +295,24 @@ export const Swap: React.FC = () => {
 	}
 
 	const handleSetAmount = async (event: React.ChangeEvent<HTMLInputElement>) => {
-		let { value } = event.currentTarget
-		// strip minus sign `-`
-		value = value.replace('-', '#!@?')
-		let val = parseInt(value, 10)
-		if (Number.isNaN(val)) {
-			setState(draft => {
-				draft.amount = ''
-			})
-		} else {
-			val = val >= 0 ? val : 0
-			setState(draft => {
-				draft.amount = value
-				draft.inputSide = 'from'
-			})
-		}
+		const { value } = event.currentTarget
+		const isValid = REGEX_INPUT.test(value)
+		if (!isValid) return
+
+		setState(draft => {
+			draft.amount = value
+			draft.inputSide = 'from'
+		})
 	}
 
 	const handleSetReceive = async (event: React.ChangeEvent<HTMLInputElement>) => {
-		let { value } = event.currentTarget
-		// strip minus sign `-`
-		value = value.replace('-', '#!@?')
-		let val = parseInt(value, 10)
-		if (Number.isNaN(val)) {
-			setState(draft => {
-				draft.receive = ''
-			})
-		} else {
-			val = val >= 0 ? val : 0
-			setState(draft => {
-				draft.receive = value
-				draft.inputSide = 'to'
-			})
-		}
+		const { value } = event.currentTarget
+		const isValid = REGEX_INPUT.test(value)
+		if (!isValid) return
+		setState(draft => {
+			draft.receive = value
+			draft.inputSide = 'to'
+		})
 	}
 
 	const handleSetMinimum = async (checked: boolean) => {


### PR DESCRIPTION
## Description

fixes for swap ux
- removed `disabled` prop from inputs, so the focus is not lost on the `calculate` function
- changed buttons from `loading` to `disabled` when calculation is happening so the buttons to not show a spinner.