### PR TITLE
Fix visible tokens

### DIFF
--- a/apps/extension/src/components/token-list-settings-modal/index.tsx
+++ b/apps/extension/src/components/token-list-settings-modal/index.tsx
@@ -51,11 +51,12 @@ const makeVisibleTokenData = (
 	availableBalances: TokenAmount[],
 ): VisibleTokens => {
 	const vs = { ...visibleTokens }
+	const hidden = Object.keys(vs).length === 0
 	availableBalances?.forEach(token => {
 		if (vs[token.rri]) return
 		const visibleToken = _tokens[token.rri]
 		if (visibleToken) {
-			vs[token.rri] = { ...visibleToken, hidden: true }
+			vs[token.rri] = { ...visibleToken, hidden }
 		}
 	})
 	return vs

--- a/apps/extension/src/components/token-list-settings-modal/index.tsx
+++ b/apps/extension/src/components/token-list-settings-modal/index.tsx
@@ -51,7 +51,7 @@ const makeVisibleTokenData = (
 	availableBalances: TokenAmount[],
 ): VisibleTokens => {
 	const vs = { ...visibleTokens }
-	const hidden = Object.keys(vs).length === 0
+	const hidden = Object.keys(vs).length > 0
 	availableBalances?.forEach(token => {
 		if (vs[token.rri]) return
 		const visibleToken = _tokens[token.rri]

--- a/apps/extension/src/components/token-list-settings-modal/index.tsx
+++ b/apps/extension/src/components/token-list-settings-modal/index.tsx
@@ -45,7 +45,7 @@ const defaultProps = {
 const getIsQueryMatch = (search: string, _token: VisibleToken): boolean =>
 	(search !== '' && _token.name?.toLowerCase().includes(search)) || _token.symbol?.toLowerCase().includes(search)
 
-const makeVisibleTokenTokenData = (
+const makeVisibleTokenData = (
 	_tokens: VisibleTokens,
 	visibleTokens: VisibleTokens,
 	availableBalances: TokenAmount[],
@@ -149,7 +149,7 @@ export const TokenListSettingsModal = ({
 	useEffect(() => {
 		if (!tokens) return
 		setState(draft => {
-			const visible = makeVisibleTokenTokenData(tokens, draft[VISIBLE], balances?.account_balances?.liquid_balances)
+			const visible = makeVisibleTokenData(tokens, draft[VISIBLE], balances?.account_balances?.liquid_balances)
 
 			draft[VISIBLE] = visible
 			draft[INVISIBLE] = makeInvisibleTokenData(draft.search.toLowerCase(), tokens, visible)
@@ -207,7 +207,7 @@ export const TokenListSettingsModal = ({
 					}
 				}
 
-				visible = makeVisibleTokenTokenData(tokens, visible, balances?.account_balances?.liquid_balances)
+				visible = makeVisibleTokenData(tokens, visible, balances?.account_balances?.liquid_balances)
 
 				draft[VISIBLE] = visible
 				draft[INVISIBLE] = makeInvisibleTokenData(draft.search.toLowerCase(), tokens, visible)
@@ -246,7 +246,7 @@ export const TokenListSettingsModal = ({
 				}
 			})
 
-			const visible = makeVisibleTokenTokenData(tokens, vs, availableBalances)
+			const visible = makeVisibleTokenData(tokens, vs, availableBalances)
 
 			draft[VISIBLE] = visible
 			draft[INVISIBLE] = makeInvisibleTokenData(draft.search.toLowerCase(), tokens, visible)

--- a/apps/extension/src/containers/wallet-panel/accounts/token-list/index.tsx
+++ b/apps/extension/src/containers/wallet-panel/accounts/token-list/index.tsx
@@ -77,17 +77,28 @@ const buildTokensForDisplay = (
 	balances: {
 		[rri: string]: VisibleToken & { amount: BigNumber }
 	},
-) => {
+): (VisibleToken & { amount: BigNumber })[] => {
 	const values = Object.values(visibleTokens)
-	return values.length === 0
-		? Object.values(balances)
-		: values
-				.filter((visibleToken: VisibleToken) => visibleToken.hidden !== true)
-				.map((visibleToken: VisibleToken) => ({
-					amount: zero,
-					...visibleToken,
-					...balances[visibleToken.rri],
-				}))
+
+	if (values.length === 0) return Object.values(balances)
+
+	const vs = values
+		.filter((visibleToken: VisibleToken) => visibleToken.hidden !== true)
+		.reduce((obj, visibleToken: VisibleToken) => {
+			obj[visibleToken.rri] = {
+				amount: zero,
+				...visibleToken,
+				...balances[visibleToken.rri],
+			}
+			return obj
+		}, {})
+
+	Object.values(balances).forEach(token => {
+		if (vs[token.rri]) return
+		vs[token.rri] = token
+	})
+
+	return Object.values(vs)
 }
 
 const AllBalances: React.FC = () => {

--- a/apps/extension/src/store/types.ts
+++ b/apps/extension/src/store/types.ts
@@ -167,8 +167,10 @@ export type WalletStore = {
 	) => Promise<void>
 
 	visibleTokens: VisibleTokens
+	hiddenTokens: VisibleTokens
 	tokenSearch: string
 	setVisibleTokensAction: (visibleTokens: VisibleTokens) => void
+	setHiddenTokensAction: (hiddenTokens: VisibleTokens) => void
 	setTokenSearchAction: (search: string) => void
 
 	activeSlideIndex: number

--- a/apps/extension/src/store/wallet.ts
+++ b/apps/extension/src/store/wallet.ts
@@ -12,6 +12,7 @@ export const whiteList = [
 	'pendingActions',
 	'networks',
 	'visibleTokens',
+	'hiddenTokens',
 	'activeSlideIndex',
 	'selectedNetworkIndex',
 	'selectedAccountIndex',
@@ -33,6 +34,7 @@ const defaultState = {
 	selectedAccountIndex: 0,
 
 	visibleTokens: {},
+	hiddenTokens: {},
 	tokenSearch: '',
 
 	publicAddresses: {},
@@ -236,6 +238,12 @@ export const factory = (set: SetState<AccountStore>, get: GetState<AccountStore>
 	setVisibleTokensAction: (visibleTokens: VisibleTokens) => {
 		set(state => {
 			state.visibleTokens = visibleTokens
+		})
+	},
+
+	setHiddenTokensAction: (hiddenTokens: VisibleTokens) => {
+		set(state => {
+			state.hiddenTokens = hiddenTokens
 		})
 	},
 

--- a/apps/extension/src/types.ts
+++ b/apps/extension/src/types.ts
@@ -73,6 +73,7 @@ export type VisibleToken = {
 	rri: string
 	name: string
 	symbol: string
+	hidden?: boolean // means token was hidden on purpase even though has positive balance
 }
 
 export type VisibleTokens = {

--- a/apps/extension/src/types.ts
+++ b/apps/extension/src/types.ts
@@ -73,7 +73,6 @@ export type VisibleToken = {
 	rri: string
 	name: string
 	symbol: string
-	hidden?: boolean // means token was hidden on purpase even though has positive balance
 }
 
 export type VisibleTokens = {


### PR DESCRIPTION
# Visible tokens

## Description

When a user organised his token list using token sorter, new balances would not appear if a token previously had 0 balance,
workaround was to reset the list and then organise it again

This PR fixes that behaviour and new tokens should appear when the balance changes if they were not specifically hidden before