### PR TITLE
style: improve min height mobile for all assets

### DIFF
--- a/packages/ui/src/components/navigation/header-navigation/index.tsx
+++ b/packages/ui/src/components/navigation/header-navigation/index.tsx
@@ -231,7 +231,6 @@ const HeaderNavInner = () => {
 					</Box>
 				</>
 			)}
-			{console.log(999, accountAddress)}
 			<Box className={clsx(styles.searchWrapper, accountAddress && styles.headerMobileHiddenWrapper)}>
 				<SearchButtonInput
 					className={clsx(styles.searchComponentWrapper)}

--- a/packages/ui/src/components/styles/panel-view-styles.css.ts
+++ b/packages/ui/src/components/styles/panel-view-styles.css.ts
@@ -2,6 +2,7 @@ import { globalKeyframes, globalStyle, style } from '@vanilla-extract/css'
 
 import { darkMode, sprinkles } from 'ui/src/components/system/sprinkles.css'
 import { responsiveStyle } from 'ui/src/components/system/theme-utils'
+import { vars } from 'ui/src/components/system/theme.css'
 
 export const panelViewOuterWrapper = style([
 	sprinkles({
@@ -46,11 +47,14 @@ export const panelViewLeftWrapper = style([
 	{},
 	responsiveStyle({
 		mobile: {
+			background: vars.color.backgroundSecondary,
 			width: '100%',
 			flexBasis: '100%',
 			zIndex: 1,
 		},
 		tablet: {
+			minHeight: 'unset !important',
+			background: 'none',
 			width: '392px',
 			flexBasis: '392px',
 			display: 'flex',

--- a/packages/ui/src/pages/accounts/components/layout/index.tsx
+++ b/packages/ui/src/pages/accounts/components/layout/index.tsx
@@ -2,6 +2,8 @@ import clsx from 'clsx'
 import React, { Suspense, useMemo } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useLocation, useMatches, useOutlet, useParams } from 'react-router-dom'
+import useMeasure from 'react-use-measure'
+import { useWindowSize } from 'usehooks-ts'
 
 import { Box } from 'ui/src/components/box'
 import { FallbackLoading, FallbackRenderer } from 'ui/src/components/fallback-renderer'
@@ -37,10 +39,16 @@ const ScrollContent: React.FC = () => {
 	const [sidebar] = sidebars.reverse()
 	const key = useMemo(() => location.pathname.split('/')[2] || '-', [location.pathname])
 
+	const [wrapperRef, { top }] = useMeasure()
+	const { height } = useWindowSize()
+	const mobileMinHeight = Math.max(height - top - 48, 435)
+
 	return (
 		<Box className={panelViewStyles.panelViewWrapper}>
 			<Box
+				ref={wrapperRef}
 				className={clsx(panelViewStyles.panelViewLeftWrapper, !!resourceId && panelViewStyles.panelViewResourceWrapper)}
+				style={{ minHeight: `${mobileMinHeight}px` }}
 			>
 				<ScrollPanel showTopScrollShadow={false} scrollParent={isMobile ? scrollableNode : undefined}>
 					<Box className={styles.accountsStickyWrapper}>

--- a/packages/ui/src/pages/accounts/home/index.tsx
+++ b/packages/ui/src/pages/accounts/home/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
 import useMeasure from 'react-use-measure'
-import { useWindowSize } from 'usehooks-ts'
 
 import { Box } from 'ui/src/components/box'
 import { CopyAddressButton } from 'ui/src/components/copy-address-button'
@@ -27,13 +26,11 @@ const Home: React.FC = () => {
 	const { accountId = '-' } = useParams()
 	const accounts = useWalletAccounts()
 	const isAllAccounts = useIsAllAccounts()
-	const [wrapperRef, { width: horizontalScrollWidth, top }] = useMeasure()
-	const { height } = useWindowSize()
-	const mobileMinHeight = Math.max(height - top - 48, 435)
+	const [wrapperRef, { width: horizontalScrollWidth }] = useMeasure()
 	const accountName = accounts?.[accountId]?.name
 
 	return (
-		<Box ref={wrapperRef} className={styles.assetsHomeWrapper} style={{ minHeight: `${mobileMinHeight}px` }}>
+		<Box ref={wrapperRef} className={styles.assetsHomeWrapper}>
 			<HomeScrollShadow />
 			<HorizontalAccountsScrollList horizontalScrollWidth={horizontalScrollWidth} />
 			<Box className={styles.homeAssetsTitleWrapper}>

--- a/packages/ui/src/pages/accounts/home/styles.css.ts
+++ b/packages/ui/src/pages/accounts/home/styles.css.ts
@@ -1,7 +1,6 @@
 import { style } from '@vanilla-extract/css'
 
 import { sprinkles } from 'ui/src/components/system/sprinkles.css'
-import { responsiveStyle } from 'ui/src/components/system/theme-utils'
 
 export const assetsHomeWrapper = style([
 	sprinkles({
@@ -10,11 +9,6 @@ export const assetsHomeWrapper = style([
 		background: 'backgroundSecondary',
 	}),
 	{},
-	responsiveStyle({
-		tablet: {
-			minHeight: 'unset !important',
-		},
-	}),
 ])
 
 export const homeAssetsTitleWrapper = style([


### PR DESCRIPTION
<img width="589" alt="image" src="https://github.com/z3us-dapps/z3us/assets/94514262/a2ff63bb-8f7a-4ab4-b0b0-7a9a17851b29">
 
fix this gap issue for assets on mobile