### PR TITLE
fix: change to instant scrolling for `scroll to top` button

### DIFF
--- a/packages/ui/src/components/scroll-area-radix/index.tsx
+++ b/packages/ui/src/components/scroll-area-radix/index.tsx
@@ -184,7 +184,7 @@ export const ScrollAreaRadix: React.FC<PropsWithChildren<IScrollAreaRadix>> = pr
 					className={clsx(styles.scrolledButtonWrapper, isScrollUpButtonVisible && styles.scrolledButtonWrapperVisible)}
 				>
 					<ToolTip message={intl.formatMessage(messages.up)} side="top">
-						<Button styleVariant="white-transparent" sizeVariant="small" iconOnly onClick={handleUpButtonClick}>
+						<Button styleVariant="ghost" sizeVariant="small" iconOnly onClick={handleUpButtonClick}>
 							<ArrowUpIcon />
 						</Button>
 					</ToolTip>

--- a/packages/ui/src/components/scroll-area-radix/index.tsx
+++ b/packages/ui/src/components/scroll-area-radix/index.tsx
@@ -83,7 +83,7 @@ export const ScrollAreaRadix: React.FC<PropsWithChildren<IScrollAreaRadix>> = pr
 		showBottomScrollShadow = true,
 		showScrollUpButton = true,
 		roundedScrollArea = false,
-		scrollTopBehavior = 'smooth',
+		scrollTopBehavior = 'instant',
 		...rest
 	} = props
 

--- a/packages/ui/src/pages/accounts/components/layout/components/mobile/scrolling-buttons/index.tsx
+++ b/packages/ui/src/pages/accounts/components/layout/components/mobile/scrolling-buttons/index.tsx
@@ -69,8 +69,8 @@ const TabTitle: React.FC = () => {
 }
 
 const HEADER_SPACE = 278
-const scrollToTop: ScrollToOptions = { top: 0, behavior: 'smooth' }
-const scrollToHeader: ScrollToOptions = { top: HEADER_SPACE, behavior: 'smooth' }
+const scrollToTop: ScrollToOptions = { top: 0, behavior: 'instant' }
+const scrollToHeader: ScrollToOptions = { top: HEADER_SPACE, behavior: 'instant' }
 
 export const MobileScrollingButtons: React.FC = () => {
 	const intl = useIntl()


### PR DESCRIPTION
smooth scrolling was not working correctly for scroll areas with a virtuoso list.