### PR TITLE
fix: update memoized table components when the sorting changes

### DIFF
--- a/packages/ui/src/components/table/index.tsx
+++ b/packages/ui/src/components/table/index.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { assignInlineVars } from '@vanilla-extract/dynamic'
 import clsx, { type ClassValue } from 'clsx'
-import { sortBy } from 'lodash'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useRowSelect, useSortBy, useTable } from 'react-table'
 import useMeasure from 'react-use-measure'
@@ -146,7 +145,7 @@ export const Table: React.FC<ITableProps> = props => {
 				/>
 			)),
 		}),
-		[data, columns, loading, loadMore, JSON.stringify(state?.sortBy || {})],
+		[data, columns, loading, loadMore, state?.sortBy?.id, state?.sortBy?.desc],
 	)
 
 	const scrollableNodeBounding = (scrollableNode?.getBoundingClientRect() || {}) as DOMRect


### PR DESCRIPTION
fix issue where row `floop` is selected 
![image](https://github.com/z3us-dapps/z3us/assets/94514262/fbab9232-484e-473b-9904-85aaf601fe6b)


but the right hand side showing wrong 
![image](https://github.com/z3us-dapps/z3us/assets/94514262/904aa161-41bb-42b8-892a-8abea59815ff)
