### PR TITLE
[+] Import Raw Private Key (HEX).

### DIFF
--- a/apps/extension/src/crypto/key_pair.ts
+++ b/apps/extension/src/crypto/key_pair.ts
@@ -60,6 +60,15 @@ export function getPrivateKey(data: Data, curve: CURVE, derivationPath: string):
 			}
 		case DataType.PRIVATE_KEY:
 			return deriveHDKey(hdkeyFromExtendedPrivateKey(secret), derivationPath)
+		case DataType.RAW_PRIVATE_KEY:
+			switch (curve) {
+				case CURVE.SECP256K1:
+					return new PrivateKey.Secp256k1(secret)
+				case CURVE.CURVE25519:
+					return new PrivateKey.Ed25519(secret)
+				default:
+					return null
+			}
 		default:
 			return null
 	}

--- a/apps/extension/src/crypto/secret.ts
+++ b/apps/extension/src/crypto/secret.ts
@@ -29,6 +29,7 @@ export function getSecret(data: Data): string {
 		case DataType.MNEMONIC:
 			return entropyToMnemonic(Buffer.from(data.secret, 'hex'), getWordList(data?.language ?? Language.ENGLISH))
 		case DataType.PRIVATE_KEY:
+		case DataType.RAW_PRIVATE_KEY:
 		case DataType.STRING:
 			return data.secret
 		case DataType.NONE:
@@ -58,6 +59,7 @@ export function secretToData(type: DataType, secret: string = '', language: Lang
 				language,
 			}
 		case DataType.PRIVATE_KEY:
+		case DataType.RAW_PRIVATE_KEY:
 		case DataType.STRING:
 			return {
 				type,

--- a/apps/extension/src/pages/keystore/options/index.tsx
+++ b/apps/extension/src/pages/keystore/options/index.tsx
@@ -34,6 +34,10 @@ const messages = defineMessages({
 		id: '4Q4DB2',
 		defaultMessage: 'Restore from extended private key',
 	},
+	raw_key: {
+		id: '4Q4DB3',
+		defaultMessage: 'Restore from raw private key hex',
+	},
 	radix: {
 		id: 'YFt45g',
 		defaultMessage: 'Connect Radix Mobile',
@@ -58,6 +62,10 @@ export const Home: React.FC = () => {
 
 	const handleRestoreExtendedPrivateKey = () => {
 		navigate('/keystore/new/restore/extended-key')
+	}
+
+	const handleRestoreRawPrivateKey = () => {
+		navigate('/keystore/new/restore/raw-key')
 	}
 
 	const handleConnectRadix = () => {
@@ -109,6 +117,11 @@ export const Home: React.FC = () => {
 					<ListItem onClick={handleRestoreExtendedPrivateKey} iconLeft={<KeyIcon />}>
 						<Text color="strong" weight="medium">
 							{intl.formatMessage(messages.key)}
+						</Text>
+					</ListItem>
+					<ListItem onClick={handleRestoreRawPrivateKey} iconLeft={<b>0x</b>}>
+						<Text color="strong" weight="medium">
+							{intl.formatMessage(messages.raw_key)}
 						</Text>
 					</ListItem>
 				</List>

--- a/apps/extension/src/pages/keystore/raw-key/restore.tsx
+++ b/apps/extension/src/pages/keystore/raw-key/restore.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react'
+import { defineMessages, useIntl } from 'react-intl'
+import { useNavigate } from 'react-router-dom'
+
+import { Box } from 'ui/src/components/box'
+import { Button } from 'ui/src/components/button'
+import { ArrowLeftIcon } from 'ui/src/components/icons'
+import { Input } from 'ui/src/components/input'
+import { KeystoreType } from 'ui/src/store/types'
+
+import { secretToData } from '@src/crypto/secret'
+import type { Data } from '@src/types/vault'
+import { DataType } from '@src/types/vault'
+
+import Done from '../components/done'
+import KeystoreForm from '../components/keystore-form'
+import { Title } from '../components/title'
+import * as styles from './styles.css'
+
+const messages = defineMessages({
+	raw_key_title: {
+		id: 'sJD8Df',
+		defaultMessage: 'Restore using raw private key',
+	},
+	raw_key_sub_title: {
+		id: 'k8GEXT',
+		defaultMessage: 'enter private key to continue (64 hex digits)',
+	},
+	raw_key_input_placeholder: {
+		id: 'IOLlx1',
+		defaultMessage: 'Enter key',
+	},
+	raw_key_continue_button: {
+		id: 'acrOoa',
+		defaultMessage: 'Continue',
+	},
+
+	raw_key_complete_title: {
+		defaultMessage: 'Create a new wallet',
+		id: 'wx278M',
+	},
+	raw_key_complete_sub_title: {
+		defaultMessage: 'The password will be used to unlock your wallet.',
+		id: 'a4CP1T',
+	},
+})
+
+export const New: React.FC = () => {
+	const navigate = useNavigate()
+	const intl = useIntl()
+
+	const [key, setKey] = useState<string>('')
+	const [step, setStep] = useState<number>(0)
+
+	const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const evt = event.nativeEvent as InputEvent
+		if (evt.isComposing) {
+			return
+		}
+
+		setKey(event.target.value)
+	}
+
+	const handleSubmit = (): Data => secretToData(DataType.RAW_PRIVATE_KEY, key.trim())
+
+	const handleDone = () => navigate('/')
+
+	switch (step) {
+		case 2:
+			return <Done onNext={handleDone} />
+
+		case 1:
+			return (
+				<Box className={styles.rawKeyWrapper}>
+					<Title
+						title={intl.formatMessage(messages.raw_key_complete_title)}
+						subTitle={intl.formatMessage(messages.raw_key_complete_sub_title)}
+					/>
+					<KeystoreForm keystoreType={KeystoreType.LOCAL} onSubmit={handleSubmit} onNext={() => setStep(2)} />
+				</Box>
+			)
+		default:
+			return (
+				<Box className={styles.rawKeyWrapper}>
+					<Button onClick={() => navigate(-1)} styleVariant="ghost" sizeVariant="small" iconOnly>
+						<ArrowLeftIcon />
+					</Button>
+					<Title
+						title={intl.formatMessage(messages.raw_key_title)}
+						subTitle={intl.formatMessage(messages.raw_key_sub_title)}
+					/>
+					<Box className={styles.rawKeyInputWrapper}>
+						<Input
+							placeholder={intl.formatMessage(messages.raw_key_input_placeholder)}
+							value={key}
+							elementType="textarea"
+							type="textarea"
+							onChange={handleChange}
+							className={styles.rawKeyInput}
+						/>
+					</Box>
+					<Button onClick={() => setStep(1)} sizeVariant="xlarge" styleVariant="primary" fullWidth disabled={!key}>
+						{intl.formatMessage(messages.raw_key_continue_button)}
+					</Button>
+				</Box>
+			)
+	}
+}
+
+export default New

--- a/apps/extension/src/pages/keystore/raw-key/styles.css.ts
+++ b/apps/extension/src/pages/keystore/raw-key/styles.css.ts
@@ -1,0 +1,31 @@
+import { style } from '@vanilla-extract/css'
+
+import { sprinkles } from 'ui/src/components/system/sprinkles.css'
+
+export const rawKeyWrapper = style([
+	sprinkles({
+		position: 'relative',
+		padding: {
+			mobile: 'xlarge',
+		},
+	}),
+	{},
+])
+
+export const rawKeyInputWrapper = style([
+	sprinkles({
+		width: 'full',
+		paddingTop: 'small',
+		paddingBottom: {
+			mobile: 'medium',
+			tablet: 'large',
+		},
+	}),
+	{},
+])
+
+export const rawKeyInput = style([
+	{
+		height: '120px',
+	},
+])

--- a/apps/extension/src/pages/keystore/router.tsx
+++ b/apps/extension/src/pages/keystore/router.tsx
@@ -8,6 +8,7 @@ const Options = lazy(() => import('./options'))
 const NewRadix = lazy(() => import('./radix'))
 const NewHW = lazy(() => import('./hardware-wallet'))
 const RestoreExtendedKey = lazy(() => import('./extended-key/restore'))
+const RestoreRawKey = lazy(() => import('./raw-key/restore'))
 
 const route = {
 	path: 'keystore',
@@ -46,6 +47,10 @@ const route = {
 						{
 							path: 'extended-key',
 							element: <RestoreExtendedKey />,
+						},
+						{
+							path: 'raw-key',
+							element: <RestoreRawKey />,
 						},
 					],
 				},

--- a/apps/extension/src/types/vault.ts
+++ b/apps/extension/src/types/vault.ts
@@ -1,6 +1,7 @@
 export enum DataType {
 	MNEMONIC = 'mnemonic',
 	PRIVATE_KEY = 'private_key',
+	RAW_PRIVATE_KEY = 'raw_private_key',
 	STRING = 'string',
 	COMBINED = 'combined',
 	NONE = 'none',


### PR DESCRIPTION
## Add support for importing Raw Private Keys (HEX).

Both new and legacy curves are supported.

## Screenshot

![image](https://github.com/z3us-dapps/z3us/assets/1646177/e10dba11-6a8e-437b-8b7c-1da92f89f3ee)

## Steps to Verify

Wallet -> add wallet -> "I already have a wallet" -> "Restore from raw private key hex". Then add a new account.
